### PR TITLE
dcm4che(issue #159) #164

### DIFF
--- a/dcm4che-core/src/main/java/org/dcm4che3/io/DicomInputStream.java
+++ b/dcm4che-core/src/main/java/org/dcm4che3/io/DicomInputStream.java
@@ -477,6 +477,12 @@ public class DicomInputStream extends FilterInputStream
                     break;
                 throw e;
             }
+            // dcm4che3#159 - Skip child tags which exceed maximum specified len.
+            if (!undeflen && (pos + length) > endPos){ 
+                LOG.warn("Tag {} with length of {} exceeds specified len of {}.  Skipping.", TagUtils.toString(tag), length, len);
+                skip(endPos - pos);
+                break;
+            }
             if (hasStopTag && tag == stopTag)
                 break;
             if (vr != null) {

--- a/dcm4che-core/src/main/java/org/dcm4che3/io/DicomInputStream.java
+++ b/dcm4che-core/src/main/java/org/dcm4che3/io/DicomInputStream.java
@@ -47,6 +47,7 @@ import java.io.FilterInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.ObjectInputStream;
+import java.io.PushbackInputStream;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -115,6 +116,7 @@ public class DicomInputStream extends FilterInputStream
     protected long markPos;
     protected int tag;
     protected VR vr;
+    private int encodedVR;
     protected int length;
     protected DicomInputHandler handler = this;
     protected BulkDataDescriptor bulkDataDescriptor = BulkDataDescriptor.DEFAULT;
@@ -387,6 +389,7 @@ public class DicomInputStream extends FilterInputStream
         byte[] buf = buffer;
         tagPos = pos; 
         readFully(buf, 0, 8);
+        encodedVR = 0;
         switch(tag = ByteUtils.bytesToTag(buf, 0, bigEndian)) {
         case Tag.Item:
         case Tag.ItemDelimitationItem:
@@ -395,7 +398,7 @@ public class DicomInputStream extends FilterInputStream
            break;
         default:
             if (explicitVR) {
-                vr = VR.valueOf(ByteUtils.bytesToVR(buf, 4));
+                vr = VR.valueOf(encodedVR = ByteUtils.bytesToVR(buf, 4));
                 if (vr.headerLength() == 8) {
                     length = ByteUtils.bytesToUShort(buf, 6, bigEndian);
                     return tag;
@@ -476,12 +479,6 @@ public class DicomInputStream extends FilterInputStream
                 if (undeflen && pos == tagPos)
                     break;
                 throw e;
-            }
-            // dcm4che3#159 - Skip child tags which exceed maximum specified len.
-            if (!undeflen && (pos + length) > endPos){ 
-                LOG.warn("Tag {} with length of {} exceeds specified len of {}.  Skipping.", TagUtils.toString(tag), length, len);
-                skip(endPos - pos);
-                break;
             }
             if (hasStopTag && tag == stopTag)
                 break;
@@ -648,6 +645,13 @@ public class DicomInputStream extends FilterInputStream
         String privateCreator = attrs.getPrivateCreator(sqtag);
         boolean undefLen = len == -1;
         long endPos = pos + (len & 0xffffffffL);
+        boolean explicitVR0 = explicitVR;
+        boolean bigEndian0 = bigEndian;
+        if (encodedVR == 0x554e // UN
+                && !probeExplicitVR()) {
+            explicitVR = false;
+            bigEndian = false;
+        }
         for (int i = 0; undefLen || pos < endPos; ++i) {
             readHeader();
             if (tag == Tag.Item) {
@@ -659,10 +663,61 @@ public class DicomInputStream extends FilterInputStream
             } else
                 skipAttribute(UNEXPECTED_ATTRIBUTE);
         }
+        explicitVR = explicitVR0;
+        bigEndian = bigEndian0;
         if (seq.isEmpty())
             attrs.setNull(sqtag, VR.SQ);
         else
             seq.trimToSize();
+    }
+    
+    private boolean probeExplicitVR() throws IOException {
+        byte[] buf = new byte[14];
+        if (in.markSupported()) {
+            in.mark(14);
+            in.read(buf);
+            in.reset();
+        } else {
+            if (!(in instanceof PushbackInputStream))
+                in = new PushbackInputStream(in, 14);
+            int len = in.read(buf);
+            ((PushbackInputStream) in).unread(buf, 0, len);
+        }
+        switch (ByteUtils.bytesToVR(buf, 12)) {
+            case 0x4145: // AE
+            case 0x4153: // AS
+            case 0x4154: // AT
+            case 0x4353: // CS
+            case 0x4441: // DA
+            case 0x4453: // DS
+            case 0x4454: // DT
+            case 0x4644: // FD
+            case 0x464c: // FL
+            case 0x4953: // IS
+            case 0x4c4f: // LO
+            case 0x4c54: // LT
+            case 0x4f42: // OB
+            case 0x4f44: // OD
+            case 0x4f46: // OF
+            case 0x4f4c: // OL
+            case 0x4f57: // OW
+            case 0x504e: // PN
+            case 0x5348: // SH
+            case 0x534c: // SL
+            case 0x5351: // SQ
+            case 0x5353: // SS
+            case 0x5354: // ST
+            case 0x544d: // TM
+            case 0x5543: // UC
+            case 0x5549: // UI
+            case 0x554c: // UL
+            case 0x554e: // UN
+            case 0x5552: // UR
+            case 0x5553: // US
+            case 0x5554: // UT
+                return true;
+        }
+        return false;
     }
 
     public Attributes readItem() throws IOException {


### PR DESCRIPTION
Prevent read of tag beyond specified length.
Toolkit detect child tags with length > the containing item length and
stop trying to parse the sequence item.